### PR TITLE
Fix build failures

### DIFF
--- a/lib/rubocop/cop/i18n/gettext/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/gettext/decorate_string.rb
@@ -63,7 +63,7 @@ module RuboCop
             if parent.respond_to?(:type) && parent.send_type?
               method_name = parent.loc.selector.source
               return if GetText.supported_decorator?(method_name)
-            elsif parent.respond_to?(:method_name) && parent.method_name == :[]
+            elsif parent.respond_to?(:method_name) && parent.method?(:[])
               return
             end
             add_offense(node, message: 'decorator is missing around sentence')

--- a/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
+++ b/lib/rubocop/cop/i18n/rails_i18n/decorate_string.rb
@@ -149,13 +149,13 @@ module RuboCop
             return true if parent.respond_to?(:method_name) && %i[raise fail].include?(parent.method_name)
 
             # Commonly exceptions are initialized manually.
-            return ignoring_raised_parent?(parent.parent) if parent.respond_to?(:method_name) && parent.method_name == :new
+            return ignoring_raised_parent?(parent.parent) if parent.respond_to?(:method_name) && parent.method?(:new)
 
             false
           end
 
           def parent_is_indexer?(parent)
-            parent.respond_to?(:method_name) && parent.method_name == :[]
+            parent.respond_to?(:method_name) && parent.method?(:[])
           end
 
           def parent_is_translator?(parent)


### PR DESCRIPTION
This autocorrects new RuboCop offenses to make the build pass beyond the
rubocop stage.